### PR TITLE
Fix README ssd1306_effects.py examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Basic micropython library to control the OLED SSD1306 128x64 I2C with a micro:bi
 
 This library allows the micro:bit to control the typical low cost 0,96" OLED display sold in Amazon and eBay connected to the default I2C pins of the micro:bit. Some sort of breakout is required. Note that the Kitronik breakout does not have pre-soldered the I2C pins and you will need to attach some headers to access the I2C pins.
 
-You should connect the device’s SCL pin to micro:bit pin 19, and the device’s SDA pin to micro:bit pin 20. You also must connect the device’s ground to the micro:bit ground (pin GND). 
+You should connect the device’s SCL pin to micro:bit pin 19, and the device’s SDA pin to micro:bit pin 20. You also must connect the device’s ground to the micro:bit ground (pin GND).
 
 Due to the low memory of the micro:bit, all functions except for show_bitmap, work in zoom mode, so the effective screen resolution is 64x32 dots of 4x4 pixels of size.
 
@@ -20,7 +20,7 @@ Main features
 =============
 
 * Load a 128x64 bitmap file
-* Set and get pixel value 
+* Set and get pixel value
 * Render of text using the internal micro:bit font
 * Support of micro:bit Image object by transforming it into a stamp that can be displayed
 * Sample programs demonstrating the different functions
@@ -29,8 +29,8 @@ Main features
 Preparation and displaying of a bitmap image
 ============================================
 
-1. Create a bitmap with an image editor with only 2 bits per pixel (black and white) 
-2. Use the LCDAssistant (http://en.radzio.dxp.pl/bitmap_converter/) to generate the hex data. 
+1. Create a bitmap with an image editor with only 2 bits per pixel (black and white)
+2. Use the LCDAssistant (http://en.radzio.dxp.pl/bitmap_converter/) to generate the hex data.
 3. Copy the hex data into the bitmap_converter.py file in the sample_images folder and run it on a computer with Python.
 4. Flash a completely empty file from mu.
 5. Copy the generated file to the micro:bit using the file transfer function in mu
@@ -57,7 +57,7 @@ clear_oled()
 +++++++++++++++++++++++
 
 
-You will typically use this function after initialize(), in order to make sure that the display is blank at the beginning. 
+You will typically use this function after initialize(), in order to make sure that the display is blank at the beginning.
 
 
 show_bitmap(filename)
@@ -70,7 +70,7 @@ Displays on the OLED screen the image stored in the file *filename*. The image h
 
    from ssd1306 import initialize, clear_oled
    from ssd1306_bitmap import show_bitmap
-   
+
    initialize()
    clear_oled()
    show_bitmap("microbit_logo")
@@ -79,14 +79,14 @@ set_px(x, y, color, draw=1)
 +++++++++++++++++++++++++++++
 
 
-Paints the pixel at position x, y (of a 64x32 coordinate system) with the corresponding color (0 dark or 1 lighted). 
+Paints the pixel at position x, y (of a 64x32 coordinate system) with the corresponding color (0 dark or 1 lighted).
 If the optional parameter **draw** is set to 0 the screen will not be refreshed and **draw_screen()** needs to be called at a later stage, since multiple screen refreshes can be time consuming. This allows setting different pixels in the buffer without refreshing the screen, and finally refresh the display with the content of the buffer.
 
 .. code-block:: python
 
    from ssd1306_px import set_px
    from ssd1306 import draw_screen, initialize, clear_oled
-   
+
    initialize()
    clear_oled()
    set_px(10,10,1)
@@ -104,7 +104,7 @@ Returns the color of the given pixel (0 dark 1 lighted)
 
    from ssd1306 import initialize, clear_oled
    from ssd1306_px import get_px
-   
+
    initialize()
    clear_oled()
    color=get_px(10,10)
@@ -119,16 +119,16 @@ Prints the text given by **text** at the row x and column y. The screen is divid
 
    from ssd1306 import initialize, clear_oled
    from ssd1306_text import add_text
-   
+
    initialize()
    clear_oled()
    add_text(0, 2, "Hello, world")
-   
+
 
 create_stamp(img)
 +++++++++++++++++
 
-Creates a stamp from an Image object. A stamp is just a set of bytes that will be used to print the image on the OLED display. The function transforms any led value different than 0 to 1. A stamp is defined with 5 columns of 8 pixels each, so a stamp occupies 5 bytes of memory and can also be defined as a bytearray of 5 bytes. If the stamp has been created from an Image, the stamp will be created centering the image. This command is used in combination of **draw_stamp** 
+Creates a stamp from an Image object. A stamp is just a set of bytes that will be used to print the image on the OLED display. The function transforms any led value different than 0 to 1. A stamp is defined with 5 columns of 8 pixels each, so a stamp occupies 5 bytes of memory and can also be defined as a bytearray of 5 bytes. If the stamp has been created from an Image, the stamp will be created centering the image. This command is used in combination of **draw_stamp**
 
 
 draw_stamp(x, y, stamp, color, draw=1)
@@ -142,22 +142,22 @@ Draws the stamp on the screen at the pixel position x, y. The stamp will be prin
    from ssd1306_stamp import draw_stamp
    from ssd1306_img import create_stamp
    from microbit import Image
-   
+
    initialize()
    clear_oled()
    stamp = create_stamp(Image.HEART)
    draw_stamp(10, 10, stamp, 1)
-   
+
 
 When drawing a stamp, the contents of the screen just before the first column of the stamp and the content of the screen just after the last column of the stamp is also redrawn. This is done to allow using a function like this to perform a simple movement of a stamp:
 
 .. code-block:: python
 
     def move_stamp(x1, y1, x2, y2, stmp):
-      draw_stamp(x1, y1, stmp, 0, 0)
-      draw_stamp(x2, y2, stmp, 1, 1)
-      
-      
+        draw_stamp(x1, y1, stmp, 0, 0)
+        draw_stamp(x2, y2, stmp, 1, 1)
+
+
 The previous function removes a stamp at position x1,y1 and redraws it at position x2, y2. Note that the first draw_stamp() does not refresh the screen. The screen is only refreshed once, with the second draw_stamp(). If the stamp is 5x5 and it is centered within the 8x7 area, the stamp will be properly updated if the distance between the two coordinates is maximum one pixel.
 
 
@@ -171,14 +171,15 @@ Modifies the contrast of the screen progressively to create  pulse effect. Thank
    from ssd1306 import initialize, clear_oled
    from ssd1306_bitmap import show_bitmap
    from ssd1306_effects import pulse
-   
+
    initialize()
    clear_oled()
    show_bitmap("microbit_logo")
-   pulse()
-   
-   
-   
+   while True:
+       pulse()
+
+
+
 blink(time=1000)
 +++++++++++++++++
 
@@ -189,8 +190,9 @@ Makes the screen blink by switching it off and on.
    from ssd1306 import initialize, clear_oled
    from ssd1306_bitmap import show_bitmap
    from ssd1306_effects import blink
-   
+
    initialize()
    clear_oled()
    show_bitmap("microbit_logo")
-   blink()
+   while True:
+       blink()


### PR DESCRIPTION
The `blink()` and `pulse()` function from [ssd1306_effects.py](https://github.com/fizban99/microbit_ssd1306/blob/master/ssd1306_effects.py) only run once, if the user directly copy from the example they won't notice the different
Added while loop to keep the effect going.